### PR TITLE
Link preflopResponses.js in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,6 +389,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
+  <script src="src/preflopResponses.js"></script>
   <script>
     // Poker Game State Management
     class PokerGTOTrainer {
@@ -672,130 +673,37 @@
       }
 
 
+      
       getGTORecommendation() {
         const heroHand = this.normalizeHand(this.gameState.heroCards);
 
-        const preflopResponses = {
-          // Pocket Pairs
-          "AA": { raise: 100, call: 0, fold: 0 },
-          "KK": { raise: 100, call: 0, fold: 0 },
-          "QQ": { raise: 100, call: 0, fold: 0 },
-          "JJ": { raise: 90, call: 10, fold: 0 },
-          "TT": { raise: 85, call: 15, fold: 0 },
-          "99": { raise: 70, call: 30, fold: 0 },
-          "88": { raise: 60, call: 40, fold: 0 },
-          "77": { raise: 50, call: 50, fold: 0 },
-          "66": { raise: 40, call: 60, fold: 0 },
-          "55": { raise: 30, call: 60, fold: 10 },
-          "44": { raise: 25, call: 60, fold: 15 },
-          "33": { raise: 20, call: 55, fold: 25 },
-          "22": { raise: 15, call: 50, fold: 35 },
+        const response = typeof preflopResponses !== 'undefined'
+          ? preflopResponses[heroHand]
+          : undefined;
 
-          // Suited Broadways
-          "AKs": { raise: 100, call: 0, fold: 0 },
-          "AQs": { raise: 90, call: 10, fold: 0 },
-          "AJs": { raise: 85, call: 15, fold: 0 },
-          "ATs": { raise: 80, call: 20, fold: 0 },
-          "KQs": { raise: 75, call: 25, fold: 0 },
-          "KJs": { raise: 70, call: 30, fold: 0 },
-          "QJs": { raise: 60, call: 35, fold: 5 },
-          "JTs": { raise: 55, call: 40, fold: 5 },
+        if (response) {
+          const freq = {
+            fold: response.fold ?? 0,
+            call: response.call ?? 0,
+            raise: response.raise ?? 0,
+          };
+          const primary = Object.entries(freq).sort((a, b) => b[1] - a[1])[0][0];
+          return { primary, frequency: freq, reasoning: 'Based on preflop chart' };
+        }
 
-          // Offsuit Broadways
-          "AKo": { raise: 100, call: 0, fold: 0 },
-          "AQo": { raise: 70, call: 20, fold: 10 },
-          "AJo": { raise: 60, call: 25, fold: 15 },
-          "KQo": { raise: 50, call: 25, fold: 25 },
+        const handStrength = this.evaluateHandStrength(
+          this.gameState.heroCards,
+          this.gameState.communityCards.slice(0, this.getVisibleCommunityCards()),
+        );
 
-          // Suited Aces (including weaker ones)
-          "A9s": { raise: 65, call: 25, fold: 10 },
-          "A8s": { raise: 60, call: 25, fold: 15 },
-          "A7s": { raise: 55, call: 25, fold: 20 },
-          "A6s": { raise: 50, call: 25, fold: 25 },
-          "A5s": { raise: 70, call: 20, fold: 10 }, // Wheel potential
-          "A4s": { raise: 65, call: 25, fold: 10 },
-          "A3s": { raise: 60, call: 25, fold: 15 },
-          "A2s": { raise: 60, call: 25, fold: 15 },
-
-          // Strong Suited Connectors
-          "KTs": { raise: 50, call: 35, fold: 15 },
-          "QTs": { raise: 45, call: 35, fold: 20 },
-          "J9s": { raise: 40, call: 40, fold: 20 },
-          "T9s": { raise: 40, call: 40, fold: 20 },
-          "98s": { raise: 35, call: 45, fold: 20 },
-          "87s": { raise: 30, call: 50, fold: 20 },
-          "76s": { raise: 25, call: 55, fold: 20 },
-          "65s": { raise: 20, call: 50, fold: 30 },
-          "54s": { raise: 15, call: 45, fold: 40 },
-
-          // Other Notable Hands
-          "K9s": { raise: 25, call: 45, fold: 30 },
-          "Q9s": { raise: 20, call: 40, fold: 40 },
-          "J8s": { raise: 15, call: 45, fold: 40 },
-          "T8s": { raise: 10, call: 40, fold: 50 }
-        };
-
-
-
-
-        const action = preflopResponses[heroHand];
-
-          // Fallback strategy if the hand isn't explicitly in the lookup table
-          if (!action) {
-            const handStrength = this.evaluateHandStrength(this.gameState.heroCards, this.gameState.communityCards.slice(0, this.getVisibleCommunityCards()));
-
-            if (handStrength >= 5) {
-              return { primary: 'raise', frequency: { fold: 5, call: 25, raise: 70 }, reasoning: 'Strong hand, bet for value' };
-            } else if (handStrength >= 3) {
-              return { primary: 'call', frequency: { fold: 30, call: 50, raise: 20 }, reasoning: 'Decent hand, call to see more cards' };
-            } else {
-              return { primary: 'fold', frequency: { fold: 70, call: 20, raise: 10 }, reasoning: 'Weak hand, fold to pressure' };
-            }
-          }
-
-          if (action === 'raise') {
-            return {
-              primary: 'raise',
-              frequency: { fold: 0, call: 10, raise: 90 },
-              reasoning: 'Strong hand, raise for value'
-            };
-          } else if (action === 'call') {
-            return {
-              primary: 'call',
-              frequency: { fold: 20, call: 60, raise: 20 },
-              reasoning: 'Playable hand, call to see the flop'
-            };
-          } else {
-            return {
-              primary: 'fold',
-              frequency: { fold: 80, call: 15, raise: 5 },
-              reasoning: 'Weak hand, fold preflop'
-            };
-          }
-
+        if (handStrength >= 5) {
+          return { primary: 'raise', frequency: { fold: 5, call: 25, raise: 70 }, reasoning: 'Strong hand, bet for value' };
+        } else if (handStrength >= 3) {
+          return { primary: 'call', frequency: { fold: 30, call: 50, raise: 20 }, reasoning: 'Decent hand, call to see more cards' };
+        } else {
+          return { primary: 'fold', frequency: { fold: 70, call: 20, raise: 10 }, reasoning: 'Weak hand, fold to pressure' };
+        }
       }
-
-
-getPreflopHandKey(cards) {
-  const [c1, c2] = cards;
-  const r1 = c1[0];
-  const r2 = c2[0];
-  const s1 = c1.slice(1);
-  const s2 = c2.slice(1);
-
-  const suited = s1 === s2;
-  let key;
-
-  if (r1 === r2) {
-    key = r1 + r2; // e.g. 'QQ'
-  } else {
-    const [high, low] = [r1, r2].sort((a, b) => '23456789TJQKA'.indexOf(b) - '23456789TJQKA'.indexOf(a));
-    key = high + low + (suited ? 's' : 'o');
-  }
-
-  return key;
-}
-
 
 
       isActionCorrect(action, amount, gtoRecommendation) {


### PR DESCRIPTION
## Summary
- include `src/preflopResponses.js` so the dataset loads automatically
- remove hard-coded preflop object in `getGTORecommendation`
- compute GTO recommendation directly from chart frequencies

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840e6eee5608320bc7a0e10b7a9b244